### PR TITLE
Fix 7D thrusters max multiplier

### DIFF
--- a/modules/standard/thrusters.json
+++ b/modules/standard/thrusters.json
@@ -118,7 +118,7 @@
       "integrity": 105,
       "mass": 32,
       "maxmass": 2430,
-      "maxmul": 1.86,
+      "maxmul": 1.06,
       "minmass": 810,
       "minmul": 0.86,
       "optmass": 1620,


### PR DESCRIPTION
We can only wish 7D gave a 1.86 multiplier, fixed to true value of 1.06