### PR TITLE
Update type_10_defender.json

### DIFF
--- a/ships/type_10_defender.json
+++ b/ships/type_10_defender.json
@@ -10,7 +10,7 @@
         "speed": 179,
         "boost": 219,
         "boostEnergy": 19,
-        "baseShieldStrength": 99,
+        "baseShieldStrength": 320,
         "baseArmour": 1044,
         "hardness": 75,
         "hullMass": 1200,


### PR DESCRIPTION

![sc_mj1](https://user-images.githubusercontent.com/34802197/34323674-ec2f62a6-e854-11e7-86a0-7ea83fbd8c39.JPG)
![sc_mj2](https://user-images.githubusercontent.com/34802197/34323675-ec4baf7e-e854-11e7-9381-77cc72aa9586.JPG)

The value in baseShieldStrength seems to be incorrect. MJ value displayed in coriolis (31mj) doesn't match the righ shielding value for the Type 10 stock build (99mj). After some testing "baseShieldStrength": 320, seems to work outputting the right mj value.