### PR TITLE
ED 3.0: Ship changes post-beta3

### DIFF
--- a/ships/alliance_chieftain.json
+++ b/ships/alliance_chieftain.json
@@ -13,7 +13,7 @@
       "baseShieldStrength": 154,
       "baseArmour": 280,
       "hardness": 65,
-      "hullMass": 420,
+      "hullMass": 400,
       "masslock": 13,
       "pipSpeed": 0.03875,
       "pitch": 39,
@@ -35,7 +35,7 @@
     "slots": {
       "standard": [6, 6, 5, 5, 6, 4, 4],
       "hardpoints": [3, 3, 2, 1, 1, 1, 0, 0, 0, 0],
-      "internal": [5, 5, 4, 2, 2,
+      "internal": [6, 5, 4, 2, 2,
         { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1 } },
         { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1 } },
         { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1 } }
@@ -44,7 +44,7 @@
     "defaults": {
       "standard": ["6E", "6E", "5E", "5E", "6E", "4E", "4C"],
       "hardpoints": [17, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0],
-      "internal": ["03", "4e", "02", "", "2h"]
+      "internal": ["04", "4e", "02", "", "2h"]
     }
   }
 }

--- a/ships/alliance_chieftain.json
+++ b/ships/alliance_chieftain.json
@@ -21,7 +21,7 @@
       "yaw": 16,
       "crew": 2
     },
-    "retailCost": 18897696,
+    "retailCost": 19382252,
     "requirements": {
       "horizons": true
     },

--- a/ships/keelback.json
+++ b/ships/keelback.json
@@ -20,7 +20,7 @@
       "pitch": 27,
       "roll": 100,
       "yaw": 15,
-      "crew": 1
+      "crew": 2
     },
     "retailCost": 3126150,
     "bulkheads": [

--- a/ships/type_7_transport.json
+++ b/ships/type_7_transport.json
@@ -13,7 +13,7 @@
       "baseShieldStrength": 155,
       "baseArmour": 340,
       "hardness": 54,
-      "hullMass": 420,
+      "hullMass": 350,
       "masslock": 10,
       "pipSpeed": 0.16625,
       "pitch": 22,
@@ -30,14 +30,14 @@
       { "id": "Bw", "edID": 128049302, "eddbID": 777, "grp": "bh", "cost": 41182100, "mass": 63, "explres": 0.2, "kinres": 0.25, "thermres": -0.4, "hullboost": 2.5 }
     ],
     "slots": {
-      "standard": [4, 5, 5, 4, 3, 3, 5],
+      "standard": [5, 5, 5, 4, 4, 3, 5],
       "hardpoints": [1, 1, 1, 1, 0, 0, 0, 0],
-      "internal": [6, 6, 6, 5, 5, 5, 3, 3]
+      "internal": [6, 6, 6, 5, 5, 5, 3, 3, 2]
     },
     "defaults": {
       "standard": ["4E", "5E", "5E", "4E", "3E", "3E", "5C"],
       "hardpoints": [17, 17, 0, 0, 0, 0, 0, 0],
-      "internal": ["04", "04", "04", "03", "03", "49", 0, "2h"]
+      "internal": ["04", "04", "04", "03", "03", "49", 0, 0, "2h"]
     }
   }
 }


### PR DESCRIPTION
After 3.0 Beta 3, there were additional changes both to the Chieftain and the T7. I'm confident these changes are correct, but I understand if you want to wait until the 3.0 release to confirm their accuracy before merging.

The Chieftain price I don't believe actually changed, but I think the previous value in the repo had a 2.5% Elite discount applied.

Also, the Keelback now has two seats! Rejoice!