### PR TITLE
Updated Type 7 for 3.0

### DIFF
--- a/ships/type_7_transport.json
+++ b/ships/type_7_transport.json
@@ -13,7 +13,7 @@
       "baseShieldStrength": 155,
       "baseArmour": 340,
       "hardness": 54,
-      "hullMass": 420,
+      "hullMass": 350,
       "masslock": 10,
       "pipSpeed": 0.16625,
       "pitch": 22,
@@ -30,14 +30,14 @@
       { "id": "Bw", "edID": 128049302, "eddbID": 777, "grp": "bh", "cost": 41182100, "mass": 63, "explres": 0.2, "kinres": 0.25, "thermres": -0.4, "hullboost": 2.5 }
     ],
     "slots": {
-      "standard": [4, 5, 5, 4, 3, 3, 5],
+      "standard": [5, 5, 5, 4, 4, 3, 5],
       "hardpoints": [1, 1, 1, 1, 0, 0, 0, 0],
-      "internal": [6, 6, 6, 5, 5, 5, 3, 3]
+      "internal": [6, 6, 6, 5, 5, 5, 3, 3, 2]
     },
     "defaults": {
       "standard": ["4E", "5E", "5E", "4E", "3E", "3E", "5C"],
       "hardpoints": [17, 17, 0, 0, 0, 0, 0, 0],
-      "internal": ["04", "04", "04", "03", "03", "49", 0, "2h"]
+      "internal": ["04", "04", "04", "03", "03", "49", 0, 0, "2h"]
     }
   }
 }


### PR DESCRIPTION
Mass: 420 => 350
Power Plant Slot: 4 =>5
Power Distributor Slot: 4 =>5
Additional size 2 optional slot.
Changed default optionals to account for the new slot