### PR TITLE
Fix speed for Krait MK II

### DIFF
--- a/ships/krait_mkii.json
+++ b/ships/krait_mkii.json
@@ -7,7 +7,7 @@
       "manufacturer": "Faulcon DeLacy",
       "class": 2,
       "hullCost": 42409425,
-      "speed": 150,
+      "speed": 240,
       "boost": 330,
       "boostEnergy": 13,
       "baseShieldStrength": 220,


### PR DESCRIPTION
Speed is currently wrong, should be 240. Boost is already correct at 330.

See also https://inara.cz/galaxy-shipyard/27/