### PR TITLE
Fixed a bug where Meta Alloy Hull Reinforcements could not be allocat…

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -179,6 +179,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -190,6 +191,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -201,6 +203,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -305,6 +308,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -316,6 +320,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -327,6 +332,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -432,6 +438,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -443,6 +450,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -454,6 +462,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -556,6 +565,7 @@ module.exports = {
           class: 5,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -1444,6 +1454,7 @@ module.exports = {
           class: 2,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -1548,6 +1559,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -1559,6 +1571,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -1664,6 +1677,7 @@ module.exports = {
           class: 5,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -1675,6 +1689,7 @@ module.exports = {
           class: 5,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -1779,6 +1794,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -1790,6 +1806,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -1895,6 +1912,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -1906,6 +1924,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -1917,6 +1936,7 @@ module.exports = {
           class: 4,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -2388,6 +2408,7 @@ module.exports = {
           class: 5,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -2399,6 +2420,7 @@ module.exports = {
           class: 5,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -2500,6 +2522,7 @@ module.exports = {
           class: 2,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -3348,6 +3371,7 @@ module.exports = {
           class: 5,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -3460,6 +3484,7 @@ module.exports = {
           class: 3,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -3561,6 +3586,7 @@ module.exports = {
           class: 3,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,
@@ -3662,6 +3688,7 @@ module.exports = {
           class: 5,
           name: "Military",
           eligible: {
+            mahr: 1,
             hr: 1,
             scb: 1,
             mrp: 1,

--- a/dist/index.json
+++ b/dist/index.json
@@ -256,6 +256,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -268,6 +269,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -280,6 +282,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -446,6 +449,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -458,6 +462,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -470,6 +475,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -637,6 +643,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -649,6 +656,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -661,6 +669,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -831,6 +840,7 @@
 						"class": 5,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -2222,6 +2232,7 @@
 						"class": 2,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -2375,6 +2386,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -2387,6 +2399,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -2560,6 +2573,7 @@
 						"class": 5,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -2572,6 +2586,7 @@
 						"class": 5,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -2746,6 +2761,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -2758,6 +2774,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -2925,6 +2942,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -2937,6 +2955,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -2949,6 +2968,7 @@
 						"class": 4,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -3698,6 +3718,7 @@
 						"class": 5,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -3710,6 +3731,7 @@
 						"class": 5,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -3872,6 +3894,7 @@
 						"class": 2,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -5230,6 +5253,7 @@
 						"class": 5,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -5406,6 +5430,7 @@
 						"class": 3,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -5556,6 +5581,7 @@
 						"class": 3,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,
@@ -5707,6 +5733,7 @@
 						"class": 5,
 						"name": "Military",
 						"eligible": {
+							"mahr": 1,
 							"hr": 1,
 							"scb": 1,
 							"mrp": 1,

--- a/ships/alliance_challenger.json
+++ b/ships/alliance_challenger.json
@@ -36,9 +36,9 @@
       "standard": [6, 6, 5, 5, 6, 4, 4],
       "hardpoints": [3, 2, 2, 2, 1, 1, 1, 0, 0, 0, 0],
       "internal": [6, 6, 3, 3, 2, 2,
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } }
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } }
       ]
     },
     "defaults": {

--- a/ships/alliance_chieftain.json
+++ b/ships/alliance_chieftain.json
@@ -36,9 +36,9 @@
       "standard": [6, 6, 5, 5, 6, 4, 4],
       "hardpoints": [3, 3, 2, 1, 1, 1, 0, 0, 0, 0],
       "internal": [6, 5, 4, 2, 2,
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } }
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } }
       ]
     },
     "defaults": {

--- a/ships/alliance_crusader.json
+++ b/ships/alliance_crusader.json
@@ -37,9 +37,9 @@
       "standard": [6, 6, 5, 5, 6, 4, 4],
       "hardpoints": [3, 2, 2, 1, 1, 1, 0, 0, 0, 0],
       "internal": [6, 5, 3, 3, 2, 2,
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } }
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } }
       ]
     },
     "defaults": {

--- a/ships/anaconda.json
+++ b/ships/anaconda.json
@@ -35,7 +35,7 @@
       "hardpoints": [4, 3, 3, 3, 2, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
       "internal": [
         7, 6, 6, 6, 5, 5, 5,
-        { "class": 5, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 5, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         4, 4, 4, 2
       ]
     },

--- a/ships/eagle.json
+++ b/ships/eagle.json
@@ -34,7 +34,7 @@
       "hardpoints": [1, 1, 1, 0],
       "internal": [
         3, 2, 
-        { "class": 2, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 2, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         1, 1
       ]
     },

--- a/ships/federal_assault_ship.json
+++ b/ships/federal_assault_ship.json
@@ -37,8 +37,8 @@
       "hardpoints": [3, 3, 2, 2, 0, 0, 0, 0],
       "internal": [
         5, 5, 4, 
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         3, 2, 2
       ]
     },

--- a/ships/federal_corvette.json
+++ b/ships/federal_corvette.json
@@ -38,8 +38,8 @@
       "hardpoints": [4, 4, 3, 2, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
       "internal": [
         7, 7, 7, 6, 6, 5, 5,
-        { "class": 5, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 5, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 5, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 5, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         4, 4, 3
       ]
     },

--- a/ships/federal_dropship.json
+++ b/ships/federal_dropship.json
@@ -37,8 +37,8 @@
       "hardpoints": [3, 2, 2, 2, 2, 0, 0, 0, 0],
       "internal": [
         6, 5, 5, 4,
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         3, 3, 2
       ]
     },

--- a/ships/federal_gunship.json
+++ b/ships/federal_gunship.json
@@ -38,9 +38,9 @@
       "hardpoints": [3, 2, 2, 2, 2, 1, 1, 0, 0, 0, 0],
       "internal": [
         6, 6, 5,
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 4, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 4, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         2, 2
       ]
     },

--- a/ships/imperial_cutter.json
+++ b/ships/imperial_cutter.json
@@ -38,8 +38,8 @@
       "hardpoints": [4, 3, 3, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0],
       "internal": [
         8, 8, 6, 6, 6, 5, 5,
-        { "class": 5, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
-        { "class": 5, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 5, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 5, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         4, 3
       ]
     },

--- a/ships/imperial_eagle.json
+++ b/ships/imperial_eagle.json
@@ -34,7 +34,7 @@
       "hardpoints": [2, 1, 1, 0],
       "internal": [
         3, 2, 
-        { "class": 2, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 2, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         1, 1
       ]
     },

--- a/ships/type_10_defender.json
+++ b/ships/type_10_defender.json
@@ -33,7 +33,7 @@
       "slots": {
         "standard": [8, 7, 7, 5, 7, 4, 6],
         "hardpoints": [3, 3, 3, 3, 2, 2, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-        "internal": [8, 7, 6, 5, 4, 4, 3, 3, 2,{ "class": 5, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },{ "class": 5, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } }]
+        "internal": [8, 7, 6, 5, 4, 4, 3, 3, 2,{ "class": 5, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },{ "class": 5, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } }]
       },
       "defaults": {
         "standard": ["6E", "7E", "6E", "5E", "7E", "4E", "6C"],

--- a/ships/viper.json
+++ b/ships/viper.json
@@ -34,7 +34,7 @@
       "hardpoints": [2, 2, 1, 1, 0, 0],
       "internal": [
         3, 3,
-        { "class": 3, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 3, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         2, 1
       ]
     },

--- a/ships/viper_mk_iv.json
+++ b/ships/viper_mk_iv.json
@@ -34,7 +34,7 @@
       "hardpoints": [2, 2, 1, 1, 0, 0],
       "internal": [
         4, 4, 3,
-        { "class": 3, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 3, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         2, 2, 1
       ]
     },

--- a/ships/vulture.json
+++ b/ships/vulture.json
@@ -34,7 +34,7 @@
       "hardpoints": [3, 3, 0, 0, 0, 0],
       "internal": [
         5, 
-        { "class": 5, "name": "Military", "eligible": { "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
+        { "class": 5, "name": "Military", "eligible": { "mahr":1, "hr": 1, "scb": 1, "mrp": 1, "gsrp": 1, "gmrp": 1, "ghrp": 1 } },
         4, 2, 1, 1
       ]
     },


### PR DESCRIPTION
Fixed a bug where Meta Alloy Hull Reinforcements could not be allocated in a military type slot. Added eligibility grant to the module for military slots in the following ships:

- Alliance Challenger
- Alliance Chieftain
- Alliance Crusader
- Anaconda
- Eagle
- Federal Assault Ship
- Federal Corvette
- Federal Dropship
- Federal Gungship
- Imperial Cutter
- Imperial Eagle
- Type-10 Defender
- Viper
- Viper MKIV
- Vulture

