### PR TITLE
Fix challenger base speed

### DIFF
--- a/ships/alliance_challenger.json
+++ b/ships/alliance_challenger.json
@@ -7,7 +7,7 @@
       "manufacturer": "Lakon",
       "class": 2,
       "hullCost": 28041035,
-      "speed": 130,
+      "speed": 204,
       "boost": 310,
       "boostEnergy": 19,
       "baseShieldStrength": 220,


### PR DESCRIPTION
The top speed value still is a bit off from what a player reported (`230`) and edsy (`232`) being `237` currently. Maybe that has something to do with the `"pipSpeed"` value? I don't know what this is for.