### PR TITLE
Fix for ammo capacity blueprints

### DIFF
--- a/modifications/blueprints.json
+++ b/modifications/blueprints.json
@@ -1072,7 +1072,7 @@
   "Misc_ChaffCapacity": {
     "fdname": "Misc_ChaffCapacity",
     "grades": {
-      "3": {
+      "1": {
         "components": {
           "Mechanical Scrap": 1,
           "Niobium": 1,
@@ -3104,7 +3104,7 @@
   "Misc_HeatSinkCapacity": {
     "fdname": "Misc_HeatSinkCapacity",
     "grades": {
-      "3": {
+      "1": {
         "components": {
           "Mechanical Scrap": 1,
           "Niobium": 1,
@@ -4122,7 +4122,7 @@
   "Misc_PointDefenseCapacity": {
     "fdname": "Misc_PointDefenseCapacity",
     "grades": {
-      "3": {
+      "1": {
         "components": {
           "Mechanical Scrap": 1,
           "Niobium": 1,

--- a/modifications/modules.json
+++ b/modifications/modules.json
@@ -1002,8 +1002,9 @@
     "blueprints": {
       "Misc_ChaffCapacity": {
         "grades": {
-          "3": {
+          "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -1013,26 +1014,31 @@
         "grades": {
           "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "2": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "3": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "4": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "5": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -1042,26 +1048,31 @@
         "grades": {
           "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "2": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "3": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "4": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "5": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -1071,26 +1082,31 @@
         "grades": {
           "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "2": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "3": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "4": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "5": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -2410,8 +2426,9 @@
     "blueprints": {
       "Misc_HeatSinkCapacity": {
         "grades": {
-          "3": {
+          "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -2421,26 +2438,31 @@
         "grades": {
           "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "2": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "3": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "4": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "5": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -2450,26 +2472,31 @@
         "grades": {
           "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "2": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "3": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "4": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "5": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -2479,26 +2506,31 @@
         "grades": {
           "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "2": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "3": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "4": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "5": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -4547,8 +4579,9 @@
     "blueprints": {
       "Misc_PointDefenseCapacity": {
         "grades": {
-          "3": {
+          "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -4558,26 +4591,31 @@
         "grades": {
           "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "2": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "3": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "4": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "5": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -4587,26 +4625,31 @@
         "grades": {
           "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "2": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "3": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "4": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "5": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }
@@ -4616,26 +4659,31 @@
         "grades": {
           "1": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "2": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "3": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "4": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           },
           "5": {
             "engineers": [
+              "Petra Olmanova",
               "Ram Tah"
             ]
           }


### PR DESCRIPTION
The blueprints for the ammo capacity increase of point defence,
heat sink launcher, and chaff launcher have been made more rational
in-game.  Instead of having 3 grades with only grade 3 giving an
extra usable shot, there is now only a grade 1 blueprint that results
in a capacity increase.  This blueprint has the cost of the old g3
blueprint.

Additionally, all the blueprints for these utilities are available
from both Ram Tah in the bubble and Petra Olmanova in Colonia.