### PR TITLE
Removed special_penetrator_payload for missile racks

### DIFF
--- a/modifications/modules.json
+++ b/modifications/modules.json
@@ -3368,7 +3368,6 @@
       "special_emissive_munitions",
       "special_fsd_interrupt",
       "special_overload_munitions",
-      "special_penetrator_payload",
       "special_thermal_cascade",
       "special_weapon_damage",
       "special_weapon_efficient",


### PR DESCRIPTION
Remove Penetrator Payload as a modification that can be applied to Missile Racks.