### PR TITLE
Add Mel Brandon as an Interdictor Engineer, Add G5 Wide Arc Blueprint

### DIFF
--- a/modifications/blueprints.json
+++ b/modifications/blueprints.json
@@ -2360,7 +2360,7 @@
             ]
           }
         },
-        "uuid": ### FIXME: WHERE TO FIND?
+        "uuid": "dd804ba4-5186-44b5-a096-6490b5806165"
       }
     },
     "id": 28,

--- a/modifications/blueprints.json
+++ b/modifications/blueprints.json
@@ -2337,6 +2337,30 @@
           ]
         },
         "uuid": "6c9f4098-99fa-4777-bd21-367937d1391f"
+      },
+      "5": {
+        "components": {
+          "Mechanical Components": 1,
+          "Eccentric Hyperspace Trajectories": 1,
+          "Classified Scan Fragment": 1
+        },
+        "features": {
+          "facinglimit": {
+            "facinglimit": [
+              1,
+              1.2
+            ],
+            "power": [
+              0.5,
+              0.5
+            ],
+            "ranget": [
+              -0.3,
+              -0.3
+            ]
+          }
+        },
+        "uuid": ### FIXME: WHERE TO FIND?
       }
     },
     "id": 28,

--- a/modifications/modules.json
+++ b/modifications/modules.json
@@ -1766,24 +1766,33 @@
             "engineers": [
               "Colonel Bris Dekker",
               "Felicity Farseer",
-              "Tiana Fortune"
+              "Tiana Fortune",
+              "Mel Brandon"
             ]
           },
           "2": {
             "engineers": [
               "Colonel Bris Dekker",
-              "Tiana Fortune"
+              "Tiana Fortune",
+              "Mel Brandon"
             ]
           },
           "3": {
             "engineers": [
               "Colonel Bris Dekker",
-              "Tiana Fortune"
+              "Tiana Fortune",
+              "Mel Brandon"
             ]
           },
           "4": {
             "engineers": [
-              "Colonel Bris Dekker"
+              "Colonel Bris Dekker",
+              "Mel Brandon"
+            ]
+          },
+          "5": {
+            "engineers": [
+              "Mel Brandon"
             ]
           }
         }
@@ -1794,24 +1803,33 @@
             "engineers": [
               "Colonel Bris Dekker",
               "Felicity Farseer",
-              "Tiana Fortune"
+              "Tiana Fortune",
+              "Mel Brandon"
             ]
           },
           "2": {
             "engineers": [
               "Colonel Bris Dekker",
-              "Tiana Fortune"
+              "Tiana Fortune",
+              "Mel Brandon"
             ]
           },
           "3": {
             "engineers": [
               "Colonel Bris Dekker",
-              "Tiana Fortune"
+              "Tiana Fortune",
+              "Mel Brandon"
             ]
           },
           "4": {
             "engineers": [
-              "Colonel Bris Dekker"
+              "Colonel Bris Dekker",
+              "Mel Brandon"
+            ]
+          },
+          "5": {
+            "engineers": [
+              "Mel Brandon"
             ]
           }
         }


### PR DESCRIPTION
Added Mel Brandon for G1-G5 Interdictor Blueprints (Long Range and Wide Arc).
Additionally added the G5 Wide Arc Blueprint.
A new UUID `dd804ba4-5186-44b5-a096-6490b5806165` was defined for this Blueprint.