### PR TITLE
Update Spelling for Default Localization - Python Mk II

### DIFF
--- a/ships/python_nx.json
+++ b/ships/python_nx.json
@@ -3,7 +3,7 @@
     "edID": 129030464,
     "eddbID": 0,
     "properties": {
-      "name": "Python MkII",
+      "name": "Python Mk II",
       "manufacturer": "Faulcon DeLacy",
       "class": 2,
       "hullCost": 56812626,


### PR DESCRIPTION
FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)