### PR TITLE
Updating hull pricing of Python and the Mk II 

### DIFF
--- a/ships/python.json
+++ b/ships/python.json
@@ -6,7 +6,7 @@
       "name": "Python",
       "manufacturer": "Faulcon DeLacy",
       "class": 2,
-      "hullCost": 55171380,
+      "hullCost": 55172380,
       "speed": 230,
       "boost": 300,
       "boostEnergy": 23,

--- a/ships/python_nx.json
+++ b/ships/python_nx.json
@@ -6,7 +6,7 @@
       "name": "Python Mk II",
       "manufacturer": "Faulcon DeLacy",
       "class": 2,
-      "hullCost": 56812626,
+      "hullCost": 66122374,
       "speed": 256,
       "boost": 345,
       "boostEnergy": 19,


### PR DESCRIPTION
so that retail pricing for both ships, matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.