### PR TITLE
[Fix] SCO 2A Group Fix

### DIFF
--- a/modules/standard/frame_shift_drive.json
+++ b/modules/standard/frame_shift_drive.json
@@ -1146,7 +1146,7 @@
       "edID": 129030580,
       "fuelmul": 0.013,
       "fuelpower": 2.0,
-      "grp": "fsd2",
+      "grp": "fsd",
       "id": "FY",
       "name": "Frame Shift Drive (SCO)",
       "integrity": 64,


### PR DESCRIPTION
The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.