### PR TITLE
Install uglify-js before use.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "npm run lint && npm run jasmine-no-stack",
     "start": "node generate_distribution.js",
     "build": "node generate_distribution.js",
+    "preinstall": "npm install --ignore-scripts",
     "install": "node generate_distribution.js"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: feel free to do it better!

`npm install` calls `node generate_distribution.js` due to the setting in `package.json`, but `generate_distribution.js` needs uglify-js to already be installed. If it's not installed (such as in a clean docker build before this PR) it fails as in https://github.com/EDCD/coriolis/issues/780 .