### PR TITLE
Fixes/highliner boost energy (#208)

### DIFF
--- a/ships/lynx_highliner.json
+++ b/ships/lynx_highliner.json
@@ -9,7 +9,7 @@
       "speed": 286,
       "boost": 351,
       "minthrust": 84.615,
-      "boostEnergy": 19,
+      "boostEnergy": 8,
       "boostInt": 5,
       "baseShieldStrength": 196,
       "baseArmour": 350,
@@ -22,7 +22,7 @@
       "roll": 61.80,
       "yaw": 19.57,
       "crew": 2,
-      "reserveFuelCapacity": 0.67
+      "reserveFuelCapacity": 0.75
     },
     "retailCost": 69289468,
     "bulkheads": [


### PR DESCRIPTION
* Issue 700 powerplant prices are incorrect (#4)

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

---------



* Features/add_corsair (#87)

* Adding the Corsair to the Shipyard

* Removing edId's for ship and bulkhead

* Features/add_corsair (#89)

* Adding the Corsair to the Shipyard

* Removing edId's for ship and bulkhead

* Changing FDName of Corsair

* Changing back to imperial_corsair for internal use, but Name value to 'Corsair' to match in game

* Added new Cargo Racks and Panther Clipper ship (#94)

* Features/add_corsair (#91)

* Deploy current beta.coriolis.io content to coriolis.io (#5)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* changing the fuelpower values back to 2.45 in frame_shift_drive.json after some testing.

* Removing code already in PR #98

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

---------




* Beta to live (#6)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* changing the fuelpower values back to 2.45 in frame_shift_drive.json after some testing.

* Removing code already in PR #98

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR (#8)

---------




* Beta into live (#10)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR (#8)

* Fixing missing 'falloff' value by adding the 'range' value to the data. (#9)

* Beta to live (#13)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* changing the fuelpower values back to 2.45 in frame_shift_drive.json after some testing.

* Removing code already in PR #98

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR (#8)

* Fixing missing 'falloff' value by adding the 'range' value to the data. (#9)

* Add Type 8 to the Shipyard (#12)

* Fix missile rack glitch (#11)

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR

* Type 8 Added to Shipyard

---------




* Add mandalay (#18)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* changing the fuelpower values back to 2.45 in frame_shift_drive.json after some testing.

* Removing code already in PR #98

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR (#8)

* Fixing missing 'falloff' value by adding the 'range' value to the data. (#9)

* Add Type 8 to the Shipyard (#12)

* Fix missile rack glitch (#11)

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR

* Type 8 Added to Shipyard

* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Initial Mandalay commit

* Mandalay adjustments

* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Initial Mandalay commit

* Mandalay adjustments

* Fixing Mandalay data

---------





* Add concord cannon (#22)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* changing the fuelpower values back to 2.45 in frame_shift_drive.json after some testing.

* Removing code already in PR #98

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly. (#1)

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

* Issue 600 add advanced weapons (#3)

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

---------



* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR (#8)

* Fixing missing 'falloff' value by adding the 'range' value to the data. (#9)

* Fix missile rack glitch (#11)

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR

* Add Type 8 to the Shipyard (#12)

* Fix missile rack glitch (#11)

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR

* Type 8 Added to Shipyard

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Type 8 Added to Shipyard (#14)

* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Initial Mandalay commit

* Mandalay adjustments

* Initial Addition of the Concord Cannon

* Add mandalay (#17)

* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Initial Mandalay commit

* Mandalay adjustments

* Fixing Mandalay data

---------



* Adding EDId of Concord Cannon

* Fixing up Concord numbers

---------





* Display boost intervals better (#23)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* changing the fuelpower values back to 2.45 in frame_shift_drive.json after some testing.

* Removing code already in PR #98

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly. (#1)

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

* Issue 600 add advanced weapons (#3)

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

---------



* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR (#8)

* Fixing missing 'falloff' value by adding the 'range' value to the data. (#9)

* Fix missile rack glitch (#11)

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR

* Add Type 8 to the Shipyard (#12)

* Fix missile rack glitch (#11)

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR

* Type 8 Added to Shipyard

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Type 8 Added to Shipyard (#14)

* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Initial Mandalay commit

* Mandalay adjustments

* Add mandalay (#17)

* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Initial Mandalay commit

* Mandalay adjustments

* Fixing Mandalay data

---------



* Add concord cannon (#19)

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly. (#1)

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Issue 600 add advanced weapons (#3)

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

---------



* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Fix missile rack glitch (#11)

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Type 8 Added to Shipyard (#14)

* Initial Addition of the Concord Cannon

* Adding EDId of Concord Cannon

---------




* Adding boostInt values to ships

---------





* Add mandalay (#24)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* changing the fuelpower values back to 2.45 in frame_shift_drive.json after some testing.

* Removing code already in PR #98

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR (#8)

* Fixing missing 'falloff' value by adding the 'range' value to the data. (#9)

* Add Type 8 to the Shipyard (#12)

* Fix missile rack glitch (#11)

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR

* Type 8 Added to Shipyard

* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Initial Mandalay commit

* Mandalay adjustments

* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Initial Mandalay commit

* Mandalay adjustments

* Fixing Mandalay data

* Add mandalay (#17)

* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Initial Mandalay commit

* Mandalay adjustments

* Fixing Mandalay data

---------



* Add concord cannon (#19)

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly. (#1)

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Issue 600 add advanced weapons (#3)

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

---------



* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Fix missile rack glitch (#11)

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Type 8 Added to Shipyard (#14)

* Initial Addition of the Concord Cannon

* Adding EDId of Concord Cannon

---------




* Display boost intervals better (#20)

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly. (#1)

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#2)

* Issue 600 add advanced weapons (#3)

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

---------



* Pricing update for generally available (not Guardian, trader or PP) modules, including standard, internal and hardpoints. Cross Referenced in-game. This will make pricing in Coriolis in-line with pricing in EDOMH, which is more accurate than Inara, or EDSY. Due to in-game discounts for Triple Elite status, at Jameson in Shin and various other discounts like LYR, pricing in Elite is difficult to keep track of, especially if prices have changed since launch and/or since introduction of a module.

* Adding SCO Drive Price update

* Fix missile rack glitch (#11)

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR

* Install uglify-js before use.

Fixes https://github.com/EDCD/coriolis/issues/780  .  I'm not a Node/NPM dev so if this is the Wong Way :tm: I'm open to better suggestions.

* Type 8 Added to Shipyard (#14)

* Adding boostInt values to ships

---------




* Adding BoostInt value to Mandalay

---------





* Adding the Corsair to the Shipyard

* Removing edId's for ship and bulkhead

* Features/add_corsair (#87)

* Adding the Corsair to the Shipyard

* Removing edId's for ship and bulkhead

* Features/add_corsair (#88)

* Adding the Corsair to the Shipyard

* Removing edId's for ship and bulkhead

* Changing FDName of Corsair

* Changing back to imperial_corsair for internal use, but Name value to 'Corsair' to match in game

---------





* Added new Cargo Racks and Panther Clipper ship

---------





* Features/add_panther_clipper (#95)

* Features/add_corsair (#91)

* Deploy current beta.coriolis.io content to coriolis.io (#5)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* changing the fuelpower values back to 2.45 in frame_shift_drive.json after some testing.

* Removing code already in PR #98

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

---------




* Beta to live (#6)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* changing the fuelpower values back to 2.45 in frame_shift_drive.json after some testing.

* Removing code already in PR #98

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR (#8)

---------




* Beta into live (#10)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's and AX Enhanced MC's and AX Enhanced MRs, etc. This gives sub-categories in the module selection drop down which were not there before.

* Adds missing missile modifications (#7)

* Removing Seeker special from Advanced MR (#8)

* Fixing missing 'falloff' value by adding the 'range' value to the data. (#9)

* Beta to live (#13)

* Python MkII (python_nx) (#99)

* Python MkII data and SCO FSD data

* Corrected speed/boost values to compensate for something coriolis does to the base values, changed pitch/roll/yaw values to match in game (although not fully tested yet) and added bulkhead costs and made up edID's for them since ED doesn't actually have ID's for them in the journal. Also changed the fuelpower value for the SCO 5C FSD to bring range in coriolis closer to what's in game, but 1 of the 3 values is still wrong. This gets worse on the SCO 5A, where all the values go out of whack and changing the fuelpower value does not have the same effect as it does on the 5C SCO. There is further work required here with each SCO FSD to get range to calculate properly.

* changing the fuelpower values back to 2.45 in frame_shift_drive.json after some testing.

* Removing code already in PR #98

* Setting EDDBId values to 0 as the ship and these modules do not exist in EDDB

* SCO Modules (#98)

* Add SCO Modules

* Correct SCO Rating/Symbol

* Update python_nx.json (#100)

FDEV Localization Files have a space between Mk and II. To maintain consistency, we should also maintain such a spacing. (See also: Krait Mk II in this repo and the FDEVID repo under EDCD)

* Updating hull pricing of Python and the Mk II so that retail pricing matches in game pricing. OG Python was 1,000cr out, the Mk II was 9Mcr out.

* Adding Planetary Approach Suite modules for completeness of the interface (they are in game... should be in Coriolis). This also lead to discovering a bug, where Coriolis generated an inara link that included the planetary approach suite as a module to buy, when the Super Cruise Assist module was fitted... this was simply an incorrect EDDBId on the Super Cruise Assist module and has now been updated to the correct ID. It also raised another bug, where Coriolis would generate the link with the standard Docking Computer in it, no matter which docking computer you actually installed... again, this was an incorrect ID, both computers had the same EDDB Id, this has now been corrected.

* [Fix] SCO 2A Group Fix

The group FSD2 doesn't exist. A typo added it, and freezes Coriolis on selection.

* Adjusted fall-off value for all MC's to 2km where they should be, from 1.8km, except the 'enforcer' which has no fall off. As there is no current way to suggest infinity/no fall-off, I have set this to 4.5km, which is its maximum range and therefore, more accurate than infinity anyway. This lines up with Cannon fall-off figures, which are also set to their maximum range, rather than infinity.

* Changing Enforcer falloff to 3km to match in game metric

* Adds dummy modules to facilitate improved import error handling. Removes unnecessary legacy PAS module from standard modules. Fixes /dist/index.js not being populated properly.

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Added 'Special' field to special modules (groms, packhounds, etc.) to make them easier to distinguish in the search results when typing in search words. Also split out advanced missile racks from the missile rack group of hardpoints, to help distinguish them better, as I did with advanced MC's an…